### PR TITLE
gpg: add signed descriptor verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 .idea
+signed_descriptor.txt

--- a/assets/index.html
+++ b/assets/index.html
@@ -2,6 +2,8 @@
 <head>
     <meta property="address" content="{address}" />
     <meta property="status" content="{status}" />
+    <meta property="address-index" content="{address-index}" />
+    <meta property="signed" content="{signed}" />
     <meta http-equiv="Refresh" content="{refresh-timeout}; URL={refresh-link}"></head>
 
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
@@ -130,6 +132,37 @@
                 <a href="/bitcoin">Generate new address</a>
             </small>
         </div>
+        <div class="my-3 p-3 bg-white rounded box-shadow" id="verify-block">
+            <div class="media text-muted pt-3">
+                <p class="media-body pb-3 mb-0 small lh-125 border-bottom border-gray">
+                    <strong class="d-block text-gray-dark">Don't trust, verify!</strong>
+                </p>
+            </div>
+            <div class="media text-muted pt-3">
+                <p class="media-body pb-3 mb-0 small lh-125 border-gray">
+                    <span>1. Copy the following signature into <code>file.txt</code></span>
+                </p>
+            </div>
+            <small class="d-block text-left mt-12 border-bottom">
+                <pre id="signed-text"></pre>
+            </small>
+            <div class="media text-muted pt-3">
+                <p class="media-body pb-3 mb-0 small lh-125 border-gray">
+                    <span>2. Verify the message with</span>
+                </p>
+            </div>
+            <small class="d-block text-left mt-12 border-bottom">
+                <pre>$ gpg --verify file.txt</pre>
+            </small>
+            <div class="media text-muted pt-3">
+                <p class="media-body pb-3 mb-0 small lh-125 border-gray">
+                    <span>3. Derive the address from descriptor in signed message at address index <span id="index-text"></span></span>
+                </p>
+            </div>
+            <small class="d-block text-left mt-12 border-bottom">
+                <pre>$ bitcoin-cli deriveaddresses "descriptor" "index"</pre>
+            </small>
+        </div>
     </main>
 
     <script src="https://code.jquery.com/jquery-3.4.1.slim.min.js" integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n" crossorigin="anonymous"></script>
@@ -140,21 +173,24 @@
     <script type="text/javascript">
 
         // get Info from metatag
-        function getAddress() {
-          return document.querySelector("meta[property='address']").content
-        }
-        function getStatus() {
-          return document.querySelector("meta[property='status']").content
+        function getMetatag(tag) {
+          return document.querySelector("meta[property='"+tag+"']").content
         }
 
         // Fill info into html text
-        document.getElementById("address-text").innerHTML = getAddress()
-        document.getElementById("address-link").href = "bitcoin://" + getAddress()
-        document.getElementById("status-text").innerHTML = getStatus()
+        document.getElementById("address-text").innerHTML = getMetatag('address')
+        document.getElementById("address-link").href = "bitcoin://" + getMetatag('address')
+        document.getElementById("status-text").innerHTML = getMetatag('status')
+        document.getElementById("index-text").innerHTML = getMetatag('address-index')
+
+        var signed = document.querySelector("meta[property='signed']").content
+        document.getElementById("signed-text").innerHTML = signed
+        if (signed == "")
+            document.getElementById("verify-block").style.display = "none"
 
         // Display qr code
         var qrcode = new QRCode(document.getElementById("qrcode"), {
-            text: getAddress(),
+            text: getMetatag('address'),
             width: 128,
             height: 128,
             colorDark : "#000000",

--- a/config.ini
+++ b/config.ini
@@ -3,3 +3,6 @@ datadir = ~/.bdk-bitcoin
 network = testnet
 wallet = test
 descriptor = "wpkh([c258d2e4/84h/1h/0h]tpubDDYkZojQFQjht8Tm4jsS3iuEmKjTiEGjG6KnuFNKKJb5A6ZUCUZKdvLdSDWofKi4ToRCwb9poe1XdqfUnP4jaJjCB2Zwv11ZLgSbnZSNecE/0/*)"
+
+[GPG]
+signed_descriptor = "signed_descriptor.txt"

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ use bdk::bitcoin::Address;
 
 use simple_server::{Method, Server, StatusCode};
 use bdk::electrum_client::{Client, ElectrumApi, ListUnspentRes, Error};
+use bdk::database::Database;
 
 fn prepare_home_dir() -> PathBuf {
     let mut dir = PathBuf::new();
@@ -36,7 +37,7 @@ fn prepare_home_dir() -> PathBuf {
     dir
 }
 
-fn new_address() -> Result<Address, bdk::Error> {
+fn new_address() -> Result<(Address, u32), bdk::Error> {
     let conf = Ini::load_from_file("config.ini").unwrap();
 
     let section_bdk = conf.section(Some("BDK")).unwrap();
@@ -52,11 +53,12 @@ fn new_address() -> Result<Address, bdk::Error> {
         descriptor,
         None,
         network.parse().unwrap(),
-        tree,
+        tree.clone(),
     )?;
 
     let addr = wallet.get_new_address()?;
-    Ok(addr)
+    let index = tree.get_last_index(bdk::KeychainKind::External).unwrap().unwrap_or(0);
+    Ok((addr, index))
 }
 
 fn client() -> Result<Client, Error> {
@@ -88,7 +90,14 @@ fn check_address(client: &Client, addr: &str, from_height: Option<usize>) -> Res
     Ok(array)
 }
 
-fn html(address: &str) -> Result<String, std::io::Error> {
+fn signed_descriptor() -> Result<String, std::io::Error> {
+    let conf = Ini::load_from_file("config.ini").unwrap();
+    let section_bdk = conf.section(Some("GPG")).unwrap();
+    let filename = section_bdk.get("signed_descriptor").unwrap();
+    return fs::read_to_string(filename)
+}
+
+fn html(address: &str, index: Option<&str>) -> Result<String, std::io::Error> {
     let client = client().unwrap();
     let list = check_address(&client, &address, Option::from(0)).unwrap();
 
@@ -105,9 +114,16 @@ fn html(address: &str) -> Result<String, std::io::Error> {
     };
 
     let template = fs::read_to_string("assets/index.html").unwrap();
-    let link = format!("/bitcoin/?{}", address);
+    let link = format!("/bitcoin/?{}:{}", address, index.unwrap_or(""));
+    let signed = signed_descriptor().unwrap_or("".to_string());
+    let mut address_index = index.unwrap_or("Unknown");
+    if address_index.is_empty() {
+        address_index = "Unknown"
+    }
     let txt = template
         .replace("{address}", &address)
+        .replace("{address-index}", &address_index)
+        .replace("{signed}", &signed)
         .replace("{status}", &status)
         .replace("{refresh-link}", &link)
         .replace("{refresh-timeout}", "10");
@@ -115,8 +131,8 @@ fn html(address: &str) -> Result<String, std::io::Error> {
 }
 
 fn redirect() -> Result<String, std::io::Error> {
-    let address = new_address().unwrap();
-    let link = format!("/bitcoin/?{}", address);
+    let (address, index) = new_address().unwrap();
+    let link = format!("/bitcoin/?{}:{}", address, index);
     let html = format!("<head><meta http-equiv=\"Refresh\" content=\"0; URL={}\"></head>", link);
     Ok(html)
 }
@@ -142,11 +158,12 @@ fn main() {
                 let addr = new_address();
                 //info!("addr {}", addr.to_string());
                 return match addr {
-                    Ok(a) => {
+                    Ok((a, i)) => {
                         info!("new addr {}", a.to_string());
                         let value = serde_json::json!({
                                 "network": a.network.to_string(),
-                                "address": a.to_string()
+                                "address": a.to_string(),
+                                "index": i
                             });
                         Ok(response.body(value.to_string().as_bytes().to_vec())?)
                     },
@@ -179,8 +196,10 @@ fn main() {
                 }
             }
             (&Method::GET, "/bitcoin/") => {
-                let address = request.uri().query().unwrap();
-                return match html(address) {
+                let mut query = request.uri().query().unwrap().split(":");
+                let address = query.next().unwrap();
+                let index = query.next();
+                return match html(address, index) {
                     Ok(txt) => {
                         Ok(response.body(txt.as_bytes().to_vec())?)
                     },


### PR DESCRIPTION
Sign the wallet descriptor in a file and public filename into "signed_description" option in config.ini .
Add instruction to verify and derive the address at the specific index.