### PR TITLE
Return last_unused addresses, parse .ini and create online wallet at startup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bdk = { git = "https://github.com/bitcoindevkit/bdk.git", revision = "c456a25", default-features = false }
+bdk = { git = "https://github.com/bitcoindevkit/bdk.git", rev = "c456a25", default-features = false }
 bdk-macros = "^0.2"
 simple-server = "0.4.0"
 log = "0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bdk = { version = "0.3.0", default-features = false }
+bdk = { git = "https://github.com/bitcoindevkit/bdk.git", revision = "c456a25", default-features = false }
 bdk-macros = "^0.2"
 simple-server = "0.4.0"
 log = "0.4.0"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Another Bitcoin payment service, based on [bdk](https://github.com/bitcoindevkit
 ### Get it start
 Build and run service (default port is 8080):
 ```
-cargo run server
+RUST_LOG=info cargo run
 ```
 
 Open the local web page on your browser using url [localhost:8080/bitcoin](http://localhost:8080/bitcoin).

--- a/assets/index.html
+++ b/assets/index.html
@@ -128,7 +128,7 @@
                 </center>
             </div>
             <small class="d-block text-right mt-3">
-                <a href="/bitcoin">Generate new address</a>
+                <a href="/bitcoin">Get unused address</a>
             </small>
         </div>
     </main>

--- a/config_example.ini
+++ b/config_example.ini
@@ -1,5 +1,8 @@
 [BDK]
-datadir = ~/.bdk-bitcoin
+datadir = .bdk-bitcoin
 network = testnet
 wallet = test
 descriptor = "wpkh([c258d2e4/84h/1h/0h]tpubDDYkZojQFQjht8Tm4jsS3iuEmKjTiEGjG6KnuFNKKJb5A6ZUCUZKdvLdSDWofKi4ToRCwb9poe1XdqfUnP4jaJjCB2Zwv11ZLgSbnZSNecE/0/*)"
+
+# electrum server URL must support network specified above
+electrum = "ssl://electrum.blockstream.info:60002"


### PR DESCRIPTION
Changed:
*  `/bitcoin` returns last unused address instead of a new address every time, fixes #7
*  `/bitcoin/api/new` renamed to `/bitcoin/api/last_unused` which also returns last unused address
* load and parse .ini file prior to starting server
* create  wallet once prior to starting server and share between requests
* create wallet as `online` to be able to monitor what the last unused address is
*  specify the `electrum` server url in .ini file

I also ran `cargo fmt`, if everyone uses it it will be easier to review and merge :-) 