### PR TITLE
add qrcode bitmap endpoint for last unused address

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -66,8 +66,8 @@ pub fn to_data_url<T: AsRef<[u8]>>(input: T, content_type: &str) -> String {
     format!("data:{};base64,{}", content_type, base64)
 }
 
-/// Creates QR containing `message` and encode it in data url
-fn create_bmp_base64_qr(message: &str) -> Result<String, std::io::Error> {
+/// Creates QR containing `message`
+pub fn create_bmp_qr(message: &str) -> Result<Vec<u8>, std::io::Error> {
     let qr = QrCode::new(message.as_bytes()).unwrap();
 
     // The `.mul(3)` with pixelated rescale shouldn't be needed, however, some printers doesn't
@@ -77,7 +77,13 @@ fn create_bmp_base64_qr(message: &str) -> Result<String, std::io::Error> {
 
     let mut cursor = Cursor::new(vec![]);
     bmp.write(&mut cursor).unwrap();
-    Ok(to_data_url(cursor.into_inner(), "image/bmp"))
+    Ok(cursor.into_inner())
+}
+
+/// Creates QR containing `message` and encode it in data url
+fn create_bmp_base64_qr(message: &str) -> Result<String, std::io::Error> {
+    let bitmap = create_bmp_qr(message)?;
+    Ok(to_data_url(bitmap, "image/bmp"))
 }
 
 pub fn not_found() -> String {

--- a/src/server.rs
+++ b/src/server.rs
@@ -37,6 +37,18 @@ pub fn create_server(conf: ConfigOpts, wallet: Wallet<AnyBlockchain, Tree>) -> S
         let wallet = wallet_mutex.lock().map_err(|_| gen_err())?;
 
         match (request.method(), request.uri().path()) {
+            (&Method::GET, "/bitcoin/api/last_unused_qr.bmp") => {
+                let address = last_unused_address(&*wallet);
+                match address {
+                    Ok(addr) => {
+                        info!("last unused addr {}", addr.to_string());
+                        let qr = html::create_bmp_qr(addr.to_string().as_str())?;
+                        response.header("Content-type", "image/bmp");
+                        Ok(response.body(qr)?)
+                    }
+                    Err(e) => Ok(response.body(e.to_string().as_bytes().to_vec())?),
+                }
+            }
             (&Method::GET, "/bitcoin/api/last_unused") => {
                 let address = last_unused_address(&*wallet);
                 match address {


### PR DESCRIPTION
Draft proposal to add `/bitcoin/api/last_unused_qr.bmp` endpoint for returning a qr code bitmap of your last unused address.
From thunderbiscuit request: https://github.com/lvaccaro/btctipserver/issues/14#issuecomment-814421193 .