### PR TITLE
qrcode: add white border & handle bitmap error

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -42,7 +42,8 @@ pub fn create_server(conf: ConfigOpts, wallet: Wallet<AnyBlockchain, Tree>) -> S
                 match address {
                     Ok(addr) => {
                         info!("last unused addr {}", addr.to_string());
-                        let qr = html::create_bmp_qr(addr.to_string().as_str())?;
+                        let qr = html::create_bmp_qr(addr.to_string().as_str())
+                            .map_err(|_| gen_err())?;
                         response.header("Content-type", "image/bmp");
                         Ok(response.body(qr)?)
                     }


### PR DESCRIPTION
Add white border around qrcode because most of scanner app are not able to detect it.
Try to improve error handling of qrcode generation