### PR TITLE
bip21: support bitcoin uri scheme

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,11 +159,13 @@ dependencies = [
  "env_logger",
  "log 0.4.14",
  "maud",
+ "percent-encoding",
  "qr_code",
  "rust-ini",
  "serde_json",
  "simple-server",
  "structopt",
+ "url",
 ]
 
 [[package]]
@@ -320,6 +322,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
 name = "fs2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -413,6 +425,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
+name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -483,6 +506,12 @@ checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if 1.0.0",
 ]
+
+[[package]]
+name = "matches"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "maud"
@@ -587,6 +616,12 @@ dependencies = [
  "smallvec",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pin-project-lite"
@@ -978,6 +1013,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b5220f05bb7de7f3f53c7c065e1199b3172696fe2db9f9c4d8ad9b4ee74c342"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
 name = "tokio"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -985,6 +1035,24 @@ checksum = "134af885d758d645f0f0505c9a8b3f9bf8a348fd822e112ab5248138348f1722"
 dependencies = [
  "autocfg",
  "pin-project-lite",
+]
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0"
+dependencies = [
+ "matches",
+]
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07fbfce1c8a97d547e8b5334978438d9d6ec8c20e38f56d4a4374d181493eaef"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]
@@ -1010,6 +1078,19 @@ name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "url"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ccd964113622c8e9322cfac19eb1004a07e636c545f325da085d5cdde6f1f8b"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "matches",
+ "percent-encoding",
+ "serde",
+]
 
 [[package]]
 name = "vec_map"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ structopt = "0.3"
 qr_code = { version="1.0.0", features = ["bmp"] }
 maud = "0.22.1"
 base64 = "0.13.0"
+url = { version = "2", features = ["serde"] }
+percent-encoding = "2.1.0"
 
 [features]
 default = ["electrum", "bdk/key-value-db"]

--- a/src/bip21.rs
+++ b/src/bip21.rs
@@ -1,11 +1,13 @@
+use bdk::bitcoin::{Address, Amount, Denomination};
 use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
 use std::collections::BTreeMap;
+use std::str::FromStr;
 use url::{ParseError, Url};
 
 pub struct Bip21 {
     pub scheme: String,
-    pub address: String,
-    pub amount: Option<String>,
+    pub address: Address,
+    pub amount: Option<Amount>,
     pub label: Option<String>,
     pub message: Option<String>,
 }
@@ -15,7 +17,7 @@ impl Bip21 {
         const FRAGMENT: &AsciiSet = &CONTROLS.add(b' ');
         let mut query = BTreeMap::new();
         if let Some(a) = &self.amount {
-            query.insert("amount", a.to_string());
+            query.insert("amount", a.as_btc().to_string());
         }
         if let Some(l) = &self.label {
             let encoded = utf8_percent_encode(l.as_str(), FRAGMENT).to_string();
@@ -29,7 +31,12 @@ impl Bip21 {
             .into_iter()
             .map(|(k, v)| format!("{}={}", k, v))
             .collect::<Vec<String>>();
-        let url = format!("{}:{}?{}", self.scheme, self.address, params.join("&"));
+        let url = format!(
+            "{}:{}?{}",
+            self.scheme,
+            self.address.to_string(),
+            params.join("&")
+        );
         Ok(url.trim_end_matches("?").to_string())
     }
 
@@ -39,12 +46,23 @@ impl Bip21 {
         for (k, v) in url.query_pairs().into_owned() {
             params.insert(k, v);
         }
+        let scheme = url.scheme().to_string();
+        let address = Address::from_str(url.path()).map_err(|_| ParseError::IdnaError)?;
+        let amount = match params.get("amount") {
+            None => None,
+            Some(amount) => Some(
+                Amount::from_str_in(amount.as_str(), Denomination::Bitcoin)
+                    .map_err(|_| ParseError::IdnaError)?,
+            ),
+        };
+        let label = params.get("label").cloned();
+        let message = params.get("message").cloned();
         Ok(Bip21 {
-            scheme: url.scheme().to_string(),
-            address: url.path().to_string(),
-            amount: params.get("amount").cloned(),
-            label: params.get("label").cloned(),
-            message: params.get("message").cloned(),
+            scheme,
+            address,
+            amount,
+            label,
+            message,
         })
     }
 }
@@ -52,50 +70,55 @@ impl Bip21 {
 #[cfg(test)]
 mod test {
     use crate::bip21::Bip21;
+    use bdk::bitcoin::{Address, Amount, Denomination};
+    use std::str::FromStr;
 
     #[test]
     fn serialize() {
         let mut bip21 = Bip21 {
             scheme: "bitcoin".to_string(),
-            address: "175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W".to_string(),
+            address: Address::from_str("2NDxuABdg2uqk9MouV6f53acAwaY2GwKVHK").unwrap(),
             amount: None,
             label: None,
             message: None,
         };
         assert_eq!(
-            "bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W",
+            "bitcoin:2NDxuABdg2uqk9MouV6f53acAwaY2GwKVHK",
             bip21.as_str().unwrap()
         );
         bip21.label = Some("Luke-Jr".to_string());
         assert_eq!(
-            "bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?label=Luke-Jr",
+            "bitcoin:2NDxuABdg2uqk9MouV6f53acAwaY2GwKVHK?label=Luke-Jr",
             bip21.as_str().unwrap()
         );
-        bip21.amount = Some("20.3".to_string());
+        bip21.amount = Some(Amount::from_str_in("20.3", Denomination::Bitcoin).unwrap());
         assert_eq!(
-            "bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?amount=20.3&label=Luke-Jr",
+            "bitcoin:2NDxuABdg2uqk9MouV6f53acAwaY2GwKVHK?amount=20.3&label=Luke-Jr",
             bip21.as_str().unwrap()
         );
-        bip21.amount = Some("50".to_string());
+        bip21.amount = Some(Amount::from_str_in("50", Denomination::Bitcoin).unwrap());
         bip21.message = Some("Donation for project xyz".to_string());
         assert_eq!(
-            "bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?amount=50&label=Luke-Jr&message=Donation%20for%20project%20xyz",
+            "bitcoin:2NDxuABdg2uqk9MouV6f53acAwaY2GwKVHK?amount=50&label=Luke-Jr&message=Donation%20for%20project%20xyz",
             bip21.as_str().unwrap()
         );
     }
 
     #[test]
     fn deserialize() {
-        let url1 = Bip21::parse("bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W").unwrap();
+        let url1 = Bip21::parse("bitcoin:2NDxuABdg2uqk9MouV6f53acAwaY2GwKVHK").unwrap();
         assert_eq!(
-            "bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W",
+            "bitcoin:2NDxuABdg2uqk9MouV6f53acAwaY2GwKVHK",
             url1.as_str().unwrap()
         );
         assert_eq!("bitcoin", url1.scheme);
-        assert_eq!("175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W", url1.address);
-        let url2 = Bip21::parse("bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?amount=50&label=Luke-Jr&message=Donation%20for%20project%20xyz").unwrap();
-        assert_eq!("bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?amount=50&label=Luke-Jr&message=Donation%20for%20project%20xyz", url2.as_str().unwrap());
-        assert_eq!("50", url2.amount.unwrap().as_str());
+        assert_eq!(
+            "2NDxuABdg2uqk9MouV6f53acAwaY2GwKVHK",
+            url1.address.to_string()
+        );
+        let url2 = Bip21::parse("bitcoin:2NDxuABdg2uqk9MouV6f53acAwaY2GwKVHK?amount=50&label=Luke-Jr&message=Donation%20for%20project%20xyz").unwrap();
+        assert_eq!("bitcoin:2NDxuABdg2uqk9MouV6f53acAwaY2GwKVHK?amount=50&label=Luke-Jr&message=Donation%20for%20project%20xyz", url2.as_str().unwrap());
+        assert_eq!(50 as f64, url2.amount.unwrap().as_btc());
         assert_eq!("Luke-Jr", url2.label.unwrap().as_str());
         assert_eq!("Donation for project xyz", url2.message.unwrap().as_str());
     }

--- a/src/bip21.rs
+++ b/src/bip21.rs
@@ -1,0 +1,102 @@
+use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
+use std::collections::BTreeMap;
+use url::{ParseError, Url};
+
+pub struct Bip21 {
+    pub scheme: String,
+    pub address: String,
+    pub amount: Option<String>,
+    pub label: Option<String>,
+    pub message: Option<String>,
+}
+
+impl Bip21 {
+    pub(crate) fn as_str(&self) -> Result<String, ParseError> {
+        const FRAGMENT: &AsciiSet = &CONTROLS.add(b' ');
+        let mut query = BTreeMap::new();
+        if let Some(a) = &self.amount {
+            query.insert("amount", a.to_string());
+        }
+        if let Some(l) = &self.label {
+            let encoded = utf8_percent_encode(l.as_str(), FRAGMENT).to_string();
+            query.insert("label", encoded);
+        }
+        if let Some(m) = &self.message {
+            let encoded = utf8_percent_encode(m.as_str(), FRAGMENT).to_string();
+            query.insert("message", encoded);
+        }
+        let params = query
+            .into_iter()
+            .map(|(k, v)| format!("{}={}", k, v))
+            .collect::<Vec<String>>();
+        let url = format!("{}:{}?{}", self.scheme, self.address, params.join("&"));
+        Ok(url.trim_end_matches("?").to_string())
+    }
+
+    pub(crate) fn parse(string: &str) -> Result<Self, ParseError> {
+        let url = Url::parse(string)?;
+        let mut params = BTreeMap::new();
+        for (k, v) in url.query_pairs().into_owned() {
+            params.insert(k, v);
+        }
+        Ok(Bip21 {
+            scheme: url.scheme().to_string(),
+            address: url.path().to_string(),
+            amount: params.get("amount").cloned(),
+            label: params.get("label").cloned(),
+            message: params.get("message").cloned(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::bip21::Bip21;
+
+    #[test]
+    fn serialize() {
+        let mut bip21 = Bip21 {
+            scheme: "bitcoin".to_string(),
+            address: "175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W".to_string(),
+            amount: None,
+            label: None,
+            message: None,
+        };
+        assert_eq!(
+            "bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W",
+            bip21.as_str().unwrap()
+        );
+        bip21.label = Some("Luke-Jr".to_string());
+        assert_eq!(
+            "bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?label=Luke-Jr",
+            bip21.as_str().unwrap()
+        );
+        bip21.amount = Some("20.3".to_string());
+        assert_eq!(
+            "bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?amount=20.3&label=Luke-Jr",
+            bip21.as_str().unwrap()
+        );
+        bip21.amount = Some("50".to_string());
+        bip21.message = Some("Donation for project xyz".to_string());
+        assert_eq!(
+            "bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?amount=50&label=Luke-Jr&message=Donation%20for%20project%20xyz",
+            bip21.as_str().unwrap()
+        );
+    }
+
+    #[test]
+    fn deserialize() {
+        let url1 = Bip21::parse("bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W").unwrap();
+        assert_eq!(
+            "bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W",
+            url1.as_str().unwrap()
+        );
+        assert_eq!("bitcoin", url1.scheme);
+        assert_eq!("175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W", url1.address);
+        let url2 = Bip21::parse("bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?amount=50&label=Luke-Jr&message=Donation%20for%20project%20xyz").unwrap();
+        assert_eq!("bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?amount=50&label=Luke-Jr&message=Donation%20for%20project%20xyz", url2.as_str().unwrap());
+        assert_eq!("50", url2.amount.unwrap().as_str());
+        assert_eq!("Luke-Jr", url2.label.unwrap().as_str());
+        assert_eq!("Donation for project xyz", url2.message.unwrap().as_str());
+    }
+}

--- a/src/html.rs
+++ b/src/html.rs
@@ -130,7 +130,7 @@ pub fn page(
     let address_link = bitcoin_uri.as_str().map_err(|_| gen_err())?;
     let meta_http_content = format!("{}; URL=/bitcoin/{}", 10, address_link);
     let qr = create_bmp_base64_qr(address_link.as_str()).map_err(|_| gen_err())?;
-    let address = bitcoin_uri.address.as_str();
+    let address = bitcoin_uri.address.to_string();
 
     let html = html! {
         (DOCTYPE)
@@ -149,10 +149,10 @@ pub fn page(
                 main role="main" class="container" {
                     (inner_network(network))
                     div class="my-3 p-3 bg-white rounded box-shadow" {
-                        (inner_address(address))
+                        (inner_address(address.as_str()))
                         (inner_status(status))
                         @if let Some(amount) = &bitcoin_uri.amount {
-                            (inner_section("Amount", amount))
+                            (inner_section("Amount", amount.to_string().as_str()))
                         }
                         @if let Some(label) = &bitcoin_uri.label {
                             (inner_section("Label", label))

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod bip21;
 mod config;
 mod error;
 mod html;


### PR DESCRIPTION
update uri interface to support bip23 uri as: `/bitcoin/bitcoin:<address>?amount=<decimal>&label=<text>` .

- update webserver interface
- add bip21 struct + serialization/deserialization with url encoding
- add new section to html page if specified in the bip21 as the following image

![Screenshot 2021-05-05 at 02 54 25](https://user-images.githubusercontent.com/11627784/117087639-61849580-ad50-11eb-9716-5126a674f352.png)
